### PR TITLE
add Rust sdk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Available at [Unity](./Unity/README.md).
 ### Godot SDK
 Available at [Godot](./Godot/README.md).
 
+### Community maintained SDKs
+
+- [Rust SDK](https://github.com/chayleaf/rust-neuro-sama-game-api)
+
 ### Randy
 Randy is a simple bot that mimics the Neuro API. It makes random actions and can be used to test your game. Available at [Randy](./Randy/README.md).
 


### PR DESCRIPTION
I've added a separate section for "Community maintained SDKs" because it feels fair to mention that it's unofficial and more scalable (not bloating everything with headers), but if that isn't worth mentioning I can add a separate section for the Rust SDK.

Also, it's kinda early in development and I haven't tested it with Randy, but hopefully how fast I pushed this out should demonstrate my willingness to maintain it and handle any issues raised.