### PR TITLE
Updated to latest version of Godot (4.3)

### DIFF
--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Neuro SDK"
 run/main_scene="res://addons/neuro-sdk/examples/Example.tscn"
-config/features=PackedStringArray("4.1", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 boot_splash/bg_color=Color(0, 0, 0, 1)
 
 [autoload]


### PR DESCRIPTION
The latest version of Godot should be used. It's a one-line change. No issues after upgrading.