### PR TITLE
Godot SDK - Use Godot's built-in debugging

### DIFF
--- a/Godot/addons/neuro-sdk/actions/action_window.gd
+++ b/Godot/addons/neuro-sdk/actions/action_window.gd
@@ -58,11 +58,11 @@ func add_action(action: NeuroAction) -> void:
 
 func register() -> void:
 	if _state != State.STATE_BUILDING:
-		Log.error("Cannot register an ActionWindow more than once.")
+		push_error("Cannot register an ActionWindow more than once.")
 		return
 
 	if _actions.size() == 0:
-		Log.error("Cannot register an ActionWindow with no actions.")
+		push_error("Cannot register an ActionWindow with no actions.")
 		return
 
 	if _context_enabled:
@@ -73,9 +73,9 @@ func register() -> void:
 
 func result(execution_result: ExecutionResult) -> ExecutionResult:
 	if _state == State.STATE_BUILDING:
-		Log.error("Cannot handle a result before registering.")
+		push_error("Cannot handle a result before registering.")
 	elif _state == State.STATE_ENDED:
-		Log.error("Cannot handle a result after the ActionWindow has ended.")
+		push_error("Cannot handle a result after the ActionWindow has ended.")
 	elif execution_result.successful:
 		_end()
 	elif _state == State.STATE_FORCED:
@@ -85,7 +85,7 @@ func result(execution_result: ExecutionResult) -> ExecutionResult:
 
 func _validate_frozen() -> bool:
 	if _state != State.STATE_BUILDING:
-		Log.error("Tried to mutate action after it was registered")
+		push_error("Tried to mutate action after it was registered")
 		return false
 	return true
 

--- a/Godot/addons/neuro-sdk/actions/neuro_action.gd
+++ b/Godot/addons/neuro-sdk/actions/neuro_action.gd
@@ -23,23 +23,23 @@ func get_ws_action() -> WsAction:
 	return WsAction.new(_get_name(), _get_description(), _get_schema())
 
 func _get_name() -> String:
-	Log.error("Action._get_name() is not implemented.")
+	push_error("Action._get_name() is not implemented.")
 	return ""
 
 func _get_description() -> String:
-	Log.error("Action._get_description() is not implemented.")
+	push_error("Action._get_description() is not implemented.")
 	return ""
 
 func _get_schema() -> Dictionary:
-	Log.error("Action._get_schema() is not implemented.")
+	push_error("Action._get_schema() is not implemented.")
 	return {}
 
 func _can_be_used() -> bool:
 	return true
 
 func _validate_action(_data: IncomingData, _state: Dictionary) -> ExecutionResult:
-	Log.error("Action._validate_action() is not implemented.")
+	push_error("Action._validate_action() is not implemented.")
 	return ExecutionResult.mod_failure("Action._validate_action() is not implemented.")
 
 func _execute_action(_state: Dictionary) -> void:
-	Log.error("Action._execute_action() is not implemented.")
+	push_error("Action._execute_action() is not implemented.")

--- a/Godot/addons/neuro-sdk/messages/api/incoming_message.gd
+++ b/Godot/addons/neuro-sdk/messages/api/incoming_message.gd
@@ -7,7 +7,7 @@ func can_handle(command: String) -> bool:
 func validate(command: String, message_data: IncomingData, state: Dictionary) -> ExecutionResult:
 	var result := _validate(command, message_data, state)
 	if result == null:
-		Log.error("IncomingMessage._validate() returned null. An error probably occurred.")
+		push_error("IncomingMessage._validate() returned null. An error probably occurred.")
 		return ExecutionResult.mod_failure(Strings.action_failed_error)
 
 	return result
@@ -19,15 +19,15 @@ func execute(state: Dictionary) -> void:
 	_execute(state)
 
 func _can_handle(_command: String) -> bool:
-	Log.error("IncomingMessage._can_handle() is not implemented.")
+	push_error("IncomingMessage._can_handle() is not implemented.")
 	return false
 
 func _validate(_command: String, _data: IncomingData, _state: Dictionary) -> ExecutionResult:
-	Log.error("IncomingMessage._validate() is not implemented.")
+	push_error("IncomingMessage._validate() is not implemented.")
 	return ExecutionResult.mod_failure("IncomingMessage.validate() is not implemented.")
 
 func _report_result(_state: Dictionary, _result: ExecutionResult) -> void:
-	Log.error("IncomingMessage._report_result() is not implemented.")
+	push_error("IncomingMessage._report_result() is not implemented.")
 
 func _execute(_state: Dictionary) -> void:
-	Log.error("IncomingMessage._execute() is not implemented.")
+	push_error("IncomingMessage._execute() is not implemented.")

--- a/Godot/addons/neuro-sdk/messages/api/outgoing_message.gd
+++ b/Godot/addons/neuro-sdk/messages/api/outgoing_message.gd
@@ -1,7 +1,7 @@
 class_name OutgoingMessage
 
 func _get_command() -> String:
-	Log.error("OutgoingMessage._get_command() is not implemented.")
+	push_error("OutgoingMessage._get_command() is not implemented.")
 	return "invalid"
 
 func _get_data() -> Dictionary:

--- a/Godot/addons/neuro-sdk/messages/incoming/action.gd
+++ b/Godot/addons/neuro-sdk/messages/incoming/action.gd
@@ -34,7 +34,7 @@ func _validate(_command: String, message_data: IncomingData, state: Dictionary) 
 		return ExecutionResult.failure(Strings.action_failed_invalid_json)
 
 	if typeof(json.data) != TYPE_DICTIONARY:
-		Log.error("Action data can only be a dictionary. Other respones are not permitted for the API implementation in Godot.")
+		push_error("Action data can only be a dictionary. Other respones are not permitted for the API implementation in Godot.")
 		return ExecutionResult.failure(Strings.action_failed_invalid_json)
 
 	var action_data := IncomingData.new(json.data)
@@ -45,7 +45,7 @@ func _validate(_command: String, message_data: IncomingData, state: Dictionary) 
 func _report_result(state: Dictionary, result: ExecutionResult) -> void:
 	var id = state.get("_action_id", null);
 	if id == null:
-		Log.error("Action.report_result received no action id. It probably could not be parsed in the action. Received result: %s" % [result.message])
+		push_error("Action.report_result received no action id. It probably could not be parsed in the action. Received result: %s" % [result.message])
 		return
 
 	Websocket.send(ActionResult.new(id, result))

--- a/Godot/addons/neuro-sdk/utils/log.gd
+++ b/Godot/addons/neuro-sdk/utils/log.gd
@@ -1,16 +1,21 @@
 class_name Log
 
+
 static func debug(message: String):
-	print(message)
+	print_debug(message)
+
 
 static func info(message: String):
 	print(message)
 
+
 static func warning(message: String):
-	print(message)
+	push_warning(message)
+
 
 static func error(message: String):
-	printerr(message)
+	push_error(message )
+
 
 static func fatal(message: String):
-	printerr(message)
+	assert(false, message)

--- a/Godot/addons/neuro-sdk/websocket/command_handler.gd
+++ b/Godot/addons/neuro-sdk/websocket/command_handler.gd
@@ -7,7 +7,7 @@ var handlers: Array[IncomingMessage] = []
 func register_all() -> void:
 	var dir := DirAccess.open(INCOMING_MESSAGES_FOLDER)
 	if not dir:
-		Log.error("Could not open websocket messages directory")
+		push_error("Could not open websocket messages directory")
 		return
 
 	dir.list_dir_begin()
@@ -21,7 +21,7 @@ func register_all() -> void:
 				node.name = file_name
 				add_child(node)
 				handlers.append(node)
-				Log.info("Added websocket message node: %s" % [script_path])
+				print("Added websocket message node: %s" % [script_path])
 		file_name = dir.get_next()
 	dir.list_dir_end()
 
@@ -34,8 +34,8 @@ func handle(command: String, data: IncomingData) -> void:
 
 		var validation_result := handler.validate(command, data, state)
 		if !validation_result.successful:
-			Log.warning("Received unsuccessful execution result when handling a message")
-			Log.warning(validation_result.message)
+			push_warning("Received unsuccessful execution result when handling a message")
+			push_warning(validation_result.message)
 
 		handler.report_result(state, validation_result)
 


### PR DESCRIPTION
The `Log` class is largely redundant—Godot comes with much more powerful debugging tools out of the box. These are more flexible with their input and integrate with the debugger tab as well as the OS terminal. Here's a rundown:

`Log.info` -> `print`
The default print converts one _or more_ arguments of _**any**_ type to string in best way possible and logs them to the console.

`Log.debug` -> `print_debug`
Like print, but also prints the current stack frame. `print_stack` can also be used to print the current stack trace.

`Log.warning` -> `push_warning`
Pushes a warning to the debugger and to the OS terminal.

`Log.error` -> `push_error`
Pushes an error the the debugger and to the OS terminal. Does not  pause project execution.

`Log.fatal` -> `assert(false, message)`
`assert` can be used to print an error message *and* pause execution. This is the same as using `push_error` followed by a `breakpoint`. Keep in mind that assert is a debug feature and is only used in the editor.