### PR TITLE
Change minima/maxima to float type

### DIFF
--- a/Unity/Assets/Json/JsonSchema.cs
+++ b/Unity/Assets/Json/JsonSchema.cs
@@ -90,16 +90,16 @@ namespace NeuroSdk.Json
         public int? MaxLength { get; set; }
 
         [JsonProperty("maximum")]
-        public int? Maximum { get; set; }
+        public float? Maximum { get; set; }
 
         [JsonProperty("exclusiveMinimum")]
-        public int? ExclusiveMinimum { get; set; }
+        public float? ExclusiveMinimum { get; set; }
 
         [JsonProperty("exclusiveMaximum")]
-        public int? ExclusiveMaximum { get; set; }
+        public float? ExclusiveMaximum { get; set; }
 
         [JsonProperty("minimum")]
-        public int? Minimum { get; set; }
+        public float? Minimum { get; set; }
 
         [JsonProperty("required")]
         private List<string>? _required;


### PR DESCRIPTION
According to the current draft of the JSON schema specification (Draft 2020-12), the `minimum`, `maximum`, `exclusiveMinimum` constraints and `exclusiveMaximum` constraints should allow floating points. The current implementation allows only integers.

[Draft 2020-12 validation meta-schema](https://json-schema.org/draft/2020-12/meta/validation)

**Use case:** Action to let Neuro move to a specific position in the room. The room is bounded by walls on non-integer coordinates.

I have tested this change using [Tony](https://github.com/Pasu4/neuro-api-tony) and it works without issue.