### PR TITLE
Fix #33

### DIFF
--- a/Godot/addons/neuro-sdk/websocket/command_handler.gd
+++ b/Godot/addons/neuro-sdk/websocket/command_handler.gd
@@ -13,6 +13,8 @@ func register_all() -> void:
 	dir.list_dir_begin()
 	var file_name := dir.get_next()
 	while file_name != "":
+		if file_name.ends_with(".remap"):
+			file_name = file_name.replace(".remap", "")
 		if file_name.ends_with(".gd"):
 			var script_path := INCOMING_MESSAGES_FOLDER + file_name
 			var script = load(script_path)

--- a/Godot/addons/neuro-sdk/websocket/command_handler.gd
+++ b/Godot/addons/neuro-sdk/websocket/command_handler.gd
@@ -14,7 +14,7 @@ func register_all() -> void:
 	var file_name := dir.get_next()
 	while file_name != "":
 		if file_name.ends_with(".remap"):
-			file_name = file_name.replace(".remap", "")
+			file_name = file_name.trim_suffix(".remap")
 		if file_name.ends_with(".gd"):
 			var script_path := INCOMING_MESSAGES_FOLDER + file_name
 			var script = load(script_path)


### PR DESCRIPTION
When a Godot project is exported the resources are renamed. Mainly .remap is added to the end so this simply removes it. More info: #33