### PR TITLE
add html game runner

### DIFF
--- a/neuro-html-game-runner/LICENSE.md
+++ b/neuro-html-game-runner/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 https://github.com/hbtz-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/neuro-html-game-runner/LICENSE.md
+++ b/neuro-html-game-runner/LICENSE.md
@@ -1,9 +1,0 @@
-MIT License
-
-Copyright (c) 2024 https://github.com/hbtz-dev
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/neuro-html-game-runner/README.md
+++ b/neuro-html-game-runner/README.md
@@ -6,7 +6,7 @@
 
 ## What it does
 - First, it downloads static-web-server if it are not already present.
-- It writes the environment variable NEURO_SDK_WS_URL, if it exists, to a file `/$ENV/NEURO_SDK_WS_URL` relative to the game directory.
+- It writes the environment variable NEURO_SDK_WS_URL, if it exists, to a file `/$env/NEURO_SDK_WS_URL` relative to the game directory.
 - It uses static-web-server to serve the files for the selected game on localhost:8787.
 - The game can then be played safely from localhost:8787 in the browser.
 

--- a/neuro-html-game-runner/README.md
+++ b/neuro-html-game-runner/README.md
@@ -1,0 +1,19 @@
+# Neuro HTML Game Runner
+
+## Usage
+- Execute neuro_html_game_runner.bat next to folders containing games with .html entrypoints. Only the single script is required.
+- You can select what game to play.
+
+## What it does
+- First, it downloads static-web-server if it are not already present.
+- It writes the environment variable NEURO_SDK_WS_URL, if it exists, to a file `/$ENV/NEURO_SDK_WS_URL` relative to the game directory.
+- It uses static-web-server to serve the files for the selected game on localhost:8787.
+- The game can then be played safely from localhost:8787 in the browser.
+
+## Why?
+- HTML games are safe to run due to the browser sandbox. However, they require a local server to run in order serve game files.
+- Bundling a local server with the game is dangerous, as it requires executing untrusted code, subverting the security model of the browser.
+- This script can be used with any HTML game to run it locally safely.
+
+## Dependencies
+- https://github.com/static-web-server

--- a/neuro-html-game-runner/neuro_html_game_runner.bat
+++ b/neuro-html-game-runner/neuro_html_game_runner.bat
@@ -13,7 +13,7 @@ set "sdkUrl=https://github.com/VedalAI/neuro-game-sdk/archive/refs/tags/1.0.0.zi
 set "sdkDir=neuro-game-sdk-1.0.0"
 set "depsDir=neuro-html-game-runner\neuro_runner_deps"
 set "scriptfile=%~dp0\neuro_runner_deps\runner.ps1"
-set "runnerSHA256=9df1e88c2f658badc5c7d14edae52e6e44e1b5542b1874ce011deacb27b4d839"
+set "runnerSHA256=03869f59432e5360f516120c58c0ef48f999802cfd73420cd373e73c540270f7"
 
 :: Check if the sdk release folder exists
 if not exist "%scriptfile%" (

--- a/neuro-html-game-runner/neuro_html_game_runner.bat
+++ b/neuro-html-game-runner/neuro_html_game_runner.bat
@@ -1,0 +1,90 @@
+@echo off
+:: See https://github.com/VedalAI/neuro-game-sdk/neuro-html-game-runner/README.md for more information about this script.
+set "port=8787"
+
+:: This script uses https://github.com/static-web-server/static-web-server to serve webfiles on localhost.
+:: Please choose the correct distribution for your OS and architecture.
+set "swsUrl=https://github.com/static-web-server/static-web-server/releases/download/v2.34.0/static-web-server-v2.34.0-x86_64-pc-windows-msvc.zip"
+set "swsDir=static-web-server-v2.34.0-x86_64-pc-windows-msvc"
+set "swsExeSHA256=800468def5ae46beae94f398babbfe37cab6adf065338b71aa9b46b1da52f215"
+
+set "swsfile=%~dp0\neuro_runner_deps\static-web-server.exe"
+set "sdkUrl=https://github.com/VedalAI/neuro-game-sdk/archive/refs/tags/1.0.0.zip"
+set "sdkDir=neuro-game-sdk-1.0.0"
+set "depsDir=neuro-html-game-runner\neuro_runner_deps"
+set "scriptfile=%~dp0\neuro_runner_deps\runner.ps1"
+set "runnerSHA256=9df1e88c2f658badc5c7d14edae52e6e44e1b5542b1874ce011deacb27b4d839"
+
+:: Check if the sdk release folder exists
+if not exist "%scriptfile%" (
+    echo Downloading Runner Script...
+    powershell -Command "Invoke-WebRequest -Uri '%sdkUrl%' -OutFile '%~dp0\sdk.zip'"
+    echo Extracting Runner Script...
+    powershell -Command "Expand-Archive -Path '%~dp0\sdk.zip' -DestinationPath '%~dp0' -Force"
+    del "%~dp0\sdk.zip"
+    move "%~dp0\%sdkDir%\%depsDir%" "%~dp0\neuro_runner_deps"
+    rd /s /q "%~dp0\%sdkDir%"
+)
+
+if not exist "%scriptfile%" (
+    echo Error: File '%scriptfile%' not found.
+    exit /b 1
+)
+
+set "filechecksum="
+
+:: Calculate SHA256 hash
+for /f "skip=1 tokens=* delims=" %%# in ('certutil -hashfile "%scriptfile%" SHA256') do (
+    set "filechecksum=%%#"
+    goto :checksum_done
+)
+:checksum_done
+
+:: Remove spaces from checksum
+set "filechecksum=%filechecksum: =%"
+
+:: Compare checksums
+if /i "%runnerSHA256%"=="%filechecksum%" (
+    echo Runner Script SHA256 checksum validated.
+) else (
+    echo Checksum validation failed for runner.ps1, got %filechecksum% expected %runnerSHA256%.
+    echo Please reinstall by removing the neuro_runner_deps folder and running this script again, or update the checksum if the source is trusted.
+    exit /b 1
+)
+
+if not exist "%swsfile%" (
+    echo Downloading Static Web Server...
+    powershell -Command "Invoke-WebRequest -Uri '%swsUrl%' -OutFile '%~dp0\sws.zip'"
+    echo Extracting Static Web Server...
+    powershell -Command "Expand-Archive -Path '%~dp0\sws.zip' -DestinationPath '%~dp0' -Force"
+    del "%~dp0\sws.zip"
+    move "%~dp0\%swsDir%\static-web-server.exe" "%~dp0\neuro_runner_deps\static-web-server.exe"
+    rd /s /q "%~dp0\%swsDir%"
+)
+
+if not exist "%swsfile%" (
+    echo Error: File '%swsfile%' not found.
+    exit /b 1
+)
+
+set "filechecksum="
+
+for /f "skip=1 tokens=* delims=" %%# in ('certutil -hashfile "%swsfile%" SHA256') do (
+    set "filechecksum=%%#"
+    goto :checksum_done
+)
+:checksum_done
+
+:: Remove spaces from checksum
+set "filechecksum=%filechecksum: =%"
+
+:: Compare checksums
+if /i "%swsExeSHA256%"=="%filechecksum%" (
+    echo Static Web Server SHA256 checksum validated.
+) else (
+    echo Checksum validation failed for static-web-server.exe, got %filechecksum% expected %swsExeSHA256%.
+    echo Please reinstall by removing the neuro_runner_deps folder and running this script again, or update the checksum if the source is trusted.
+    exit /b 1
+)
+
+powershell -ExecutionPolicy Bypass -File "%scriptfile%" -port "%port%"

--- a/neuro-html-game-runner/neuro_html_game_runner.bat
+++ b/neuro-html-game-runner/neuro_html_game_runner.bat
@@ -13,7 +13,7 @@ set "sdkUrl=https://github.com/VedalAI/neuro-game-sdk/archive/refs/tags/1.0.0.zi
 set "sdkDir=neuro-game-sdk-1.0.0"
 set "depsDir=neuro-html-game-runner\neuro_runner_deps"
 set "scriptfile=%~dp0\neuro_runner_deps\runner.ps1"
-set "runnerSHA256=03869f59432e5360f516120c58c0ef48f999802cfd73420cd373e73c540270f7"
+set "runnerSHA256=599b71d1286a8b6e94871f7460779e49dc11f31ccfa37f90e9fac85f84b2c884"
 
 :: Check if the sdk release folder exists
 if not exist "%scriptfile%" (

--- a/neuro-html-game-runner/neuro_html_game_runner.bat
+++ b/neuro-html-game-runner/neuro_html_game_runner.bat
@@ -1,6 +1,6 @@
 @echo off
 :: See https://github.com/VedalAI/neuro-game-sdk/neuro-html-game-runner/README.md for more information about this script.
-set "port=8787"
+set "port=7272"
 
 :: This script uses https://github.com/static-web-server/static-web-server to serve webfiles on localhost.
 :: Please choose the correct distribution for your OS and architecture.
@@ -13,7 +13,7 @@ set "sdkUrl=https://github.com/VedalAI/neuro-game-sdk/archive/refs/tags/1.0.0.zi
 set "sdkDir=neuro-game-sdk-1.0.0"
 set "depsDir=neuro-html-game-runner\neuro_runner_deps"
 set "scriptfile=%~dp0\neuro_runner_deps\runner.ps1"
-set "runnerSHA256=599b71d1286a8b6e94871f7460779e49dc11f31ccfa37f90e9fac85f84b2c884"
+set "runnerSHA256=995a1cbed14aa76ecd051cf4b0a218481538fb4b191dd68b8c72f9fa0a1f5525"
 
 :: Check if the sdk release folder exists
 if not exist "%scriptfile%" (

--- a/neuro-html-game-runner/neuro_runner_deps/runner.ps1
+++ b/neuro-html-game-runner/neuro_runner_deps/runner.ps1
@@ -112,6 +112,14 @@ if (Test-Path env:NEURO_SDK_WS_URL) {
 $config = @"
 [advanced]
 [[advanced.headers]]
+source = "**/*"
+headers.Cross-Origin-Opener-Policy = "same-origin"
+headers.Access-Control-Allow-Methods = "GET, POST, OPTIONS"
+headers.Access-Control-Allow-Headers = "Content-Type"
+headers.Cache-Control = "no-cache, no-store, must-revalidate"
+headers.Pragma = "no-cache"
+headers.Expires = "0"
+[[advanced.headers]]
 source = "**/*.{gz}"
 headers.Content-Encoding = "gzip"
 [[advanced.headers]]

--- a/neuro-html-game-runner/neuro_runner_deps/runner.ps1
+++ b/neuro-html-game-runner/neuro_runner_deps/runner.ps1
@@ -1,0 +1,122 @@
+# This script uses https://github.com/static-web-server/ to serve webfiles on localhost.
+# Please choose the correct distribution for your OS and architecture.
+
+param(
+    [string]$port = "8787"
+)
+
+# [Environment]::SetEnvironmentVariable("NEURO_SDK_WS_URL", "localhost:8000", 'Process')
+
+$exePath = "neuro_runner_deps\static-web-server.exe"
+
+# Function to display menu and handle selection
+function Show-Menu {
+    param (
+        [string]$Title,
+        [array]$Options
+    )
+    
+    $selectedIndex = 0
+    $pressed = $null
+    $maxLength = ($Options | Measure-Object -Property Length -Maximum).Maximum
+    
+    do {
+        Clear-Host
+        Write-Host $Title -ForegroundColor Cyan
+        Write-Host
+
+        for ($i = 0; $i -lt $Options.Count; $i++) {
+            if ($i -eq $selectedIndex) {
+                Write-Host ("> " + $Options[$i].PadRight($maxLength)) -ForegroundColor Green
+            } else {
+                Write-Host ("  " + $Options[$i].PadRight($maxLength)) -ForegroundColor Gray
+            }
+        }
+
+        $pressed = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+
+        switch ($pressed.VirtualKeyCode) {
+            38 { # Up arrow
+                if ($selectedIndex -gt 0) {
+                    $selectedIndex--
+                }
+                break
+            }
+            40 { # Down arrow
+                if ($selectedIndex -lt ($Options.Count - 1)) {
+                    $selectedIndex++
+                }
+                break
+            }
+        }
+    } while ($pressed.VirtualKeyCode -ne 13) # Enter key
+
+    return $selectedIndex
+}
+
+
+# Scan for HTML game folders
+# Write-Host "Scanning for HTML games..." -ForegroundColor Yellow
+$folders = Get-ChildItem -Directory | Where-Object {
+    Test-Path (Join-Path $_.FullName "*.html")
+}
+
+if ($folders.Count -eq 0) {
+    Write-Host "`nNo HTML games found in neighboring directories." -ForegroundColor Red
+    Write-Host "Make sure game folders contain .html files."
+    Read-Host "Press Enter to exit"
+    exit
+}
+
+# Build menu options for folders
+$folderOptions = @()
+foreach ($folder in $folders) {
+    $htmlFiles = Get-ChildItem -Path $folder.FullName -Filter "*.html"
+    if ($htmlFiles.Count -eq 1) {
+        $folderOptions += "$($folder.Name) ($($htmlFiles[0].Name))"
+    } else {
+        $folderOptions += "$($folder.Name)"
+    }
+}
+
+# Show folder selection menu
+Write-Host
+$title = "These folders look like they might contain HTML games. Which do you want to play?"
+$folderIndex = Show-Menu -Title $title -Options $folderOptions
+
+$selectedFolder = $folders[$folderIndex]
+$htmlFiles = Get-ChildItem -Path $selectedFolder.FullName -Filter "*.html"
+
+# If multiple HTML files, show second menu
+if ($htmlFiles.Count -gt 1) {
+    Write-Host
+    $title = "The folder $($selectedFolder.Name) has multiple HTML files, which one is the game located at?"
+    $htmlOptions = $htmlFiles | ForEach-Object { $_.Name }
+    $fileIndex = Show-Menu -Title $title -Options $htmlOptions
+    $selectedFile = $htmlFiles[$fileIndex].Name
+} else {
+    $selectedFile = $htmlFiles[0].Name
+}
+
+Write-Host
+# Write the neuro sdk variable if present
+if (Test-Path env:NEURO_SDK_WS_URL) {
+    Write-Host "NEURO_SDK_WS_URL = $env:NEURO_SDK_WS_URL"
+    Write-Host "Writing to game directory..."
+    New-Item -ItemType Directory -Force -Path "$selectedFolder\`$ENV\"
+    $env:NEURO_SDK_WS_URL | Out-File -FilePath "$selectedFolder\`$ENV\NEURO_SDK_WS_URL"
+} else {
+   Write-Host "NEURO_SDK_WS_URL environment variable is not set."
+}
+
+# Start the server
+Write-Host
+Write-Host "[PLACEHOLDER] Starting local server..." -ForegroundColor Yellow
+Write-Host "Game will be running at http://localhost:$port/$selectedFile (Ctrl+Click to open)" -ForegroundColor Cyan
+
+# Attempt to open the browser automatically
+Start-Process "http://localhost:$port/$selectedFile"
+
+& $exePath "--port", $port, "--root", $selectedFolder
+
+

--- a/neuro-html-game-runner/neuro_runner_deps/runner.ps1
+++ b/neuro-html-game-runner/neuro_runner_deps/runner.ps1
@@ -103,8 +103,8 @@ Write-Host
 if (Test-Path env:NEURO_SDK_WS_URL) {
     Write-Host "NEURO_SDK_WS_URL = $env:NEURO_SDK_WS_URL"
     Write-Host "Writing to game directory..."
-    New-Item -ItemType Directory -Force -Path "$selectedFolder\`$ENV\"
-    $env:NEURO_SDK_WS_URL | Out-File -FilePath "$selectedFolder\`$ENV\NEURO_SDK_WS_URL"
+    New-Item -ItemType Directory -Force -Path "$selectedFolder\`$env\"
+    $env:NEURO_SDK_WS_URL | Out-File -FilePath "$selectedFolder\`$env\NEURO_SDK_WS_URL"
 } else {
    Write-Host "NEURO_SDK_WS_URL environment variable is not set."
 }

--- a/neuro-html-game-runner/neuro_runner_deps/runner.ps1
+++ b/neuro-html-game-runner/neuro_runner_deps/runner.ps1
@@ -109,6 +109,18 @@ if (Test-Path env:NEURO_SDK_WS_URL) {
    Write-Host "NEURO_SDK_WS_URL environment variable is not set."
 }
 
+$config = @"
+[advanced]
+[[advanced.headers]]
+source = "**/*.{gz}"
+headers.Content-Encoding = "gzip"
+[[advanced.headers]]
+source = "**/*.{br}"
+headers.Content-Encoding = "br"
+"@
+
+Set-Content -Path "neuro_runner_deps\server_config.toml" -Value $config
+
 # Start the server
 Write-Host
 Write-Host "[PLACEHOLDER] Starting local server..." -ForegroundColor Yellow
@@ -117,6 +129,6 @@ Write-Host "Game will be running at http://localhost:$port/$selectedFile (Ctrl+C
 # Attempt to open the browser automatically
 Start-Process "http://localhost:$port/$selectedFile"
 
-& $exePath "--port", $port, "--root", $selectedFolder
+& $exePath "--port", $port, "--root", $selectedFolder, "-w", "neuro_runner_deps\server_config.toml"
 
 


### PR DESCRIPTION
Note: For the self-install to work, you must issue a Github release with tag 1.0.0

# Neuro HTML Game Runner

## Usage
- Execute neuro_html_game_runner.bat next to folders containing games with .html entrypoints. Only the single script is required.
- You can select what game to play.

## What it does
- First, it downloads static-web-server if it are not already present.
- It writes the environment variable NEURO_SDK_WS_URL, if it exists, to a file `/$ENV/NEURO_SDK_WS_URL` relative to the game directory.
- It uses static-web-server to serve the files for the selected game on localhost:8787.
- The game can then be played safely from localhost:8787 in the browser.

## Why?
- HTML games are safe to run due to the browser sandbox. However, they require a local server to run in order serve game files.
- Bundling a local server with the game is dangerous, as it requires executing untrusted code, subverting the security model of the browser.
- This script can be used with any HTML game to run it locally safely.

## Dependencies
- https://github.com/static-web-server