### PR TITLE
Use method chaining for ActionWindow

### DIFF
--- a/Unity/Assets/Actions/ActionWindow.cs
+++ b/Unity/Assets/Actions/ActionWindow.cs
@@ -104,12 +104,15 @@ namespace NeuroSdk.Actions
         /// <summary>
         /// Set a context message to be sent alongside the action register.
         /// </summary>
-        public void SetContext(string message, bool silent = false)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetContext(string message, bool silent = false)
         {
-            if (!ValidateFrozen()) return;
+            if (!ValidateFrozen()) return this;
 
             _contextMessage = message;
             _contextSilent = silent;
+
+            return this;
         }
 
         #endregion
@@ -121,11 +124,22 @@ namespace NeuroSdk.Actions
         /// <summary>
         /// Add a new action to the list of possible actions that Neuro can pick from
         /// </summary>
-        public void AddAction(INeuroAction action)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow AddAction(INeuroAction action)
         {
-            if (!ValidateFrozen()) return;
+            if (!ValidateFrozen()) return this;
 
-            if (action.CanBeUsed()) _actions.Add(action);
+            if (action.CanAddToActionWindow(this))
+            {
+                action.SetActionWindow(this);
+                _actions.Add(action);
+            }
+            else
+            {
+                Debug.LogError("Cannot add this action to this ActionWindow.");
+            }
+
+            return this;
         }
 
         #endregion
@@ -144,14 +158,17 @@ namespace NeuroSdk.Actions
         /// <param name="queryGetter">A getter for the query of the action force, invoked at force-time.</param>
         /// <param name="stateGetter">A getter for the state of the action force, invoked at force-time.</param>
         /// <param name="ephemeralContext">If true, the query and state won't be remembered after the action force is finished.</param>
-        public void SetForce(Func<bool> shouldForce, Func<string> queryGetter, Func<string?> stateGetter, bool ephemeralContext = false)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetForce(Func<bool> shouldForce, Func<string> queryGetter, Func<string?> stateGetter, bool ephemeralContext = false)
         {
-            if (!ValidateFrozen()) return;
+            if (!ValidateFrozen()) return this;
 
             _shouldForceFunc = shouldForce;
             _forceQueryGetter = queryGetter;
             _forceStateGetter = stateGetter;
             _forceEphemeralContext = ephemeralContext;
+
+            return this;
         }
 
         /// <summary>
@@ -159,7 +176,8 @@ namespace NeuroSdk.Actions
         /// </summary>
         /// <param name="shouldForce">When this returns true, the actions will be forced.</param>
         /// <param name="ephemeralContext">If true, the query and state won't be remembered after the action force is finished.</param>
-        public void SetForce(Func<bool> shouldForce, string query, string? state, bool ephemeralContext = false)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetForce(Func<bool> shouldForce, string query, string? state, bool ephemeralContext = false)
             => SetForce(shouldForce, () => query, () => state, ephemeralContext);
 
         /// <summary>
@@ -168,12 +186,12 @@ namespace NeuroSdk.Actions
         /// <param name="queryGetter">A getter for the query of the action force, invoked at force-time.</param>
         /// <param name="stateGetter">A getter for the state of the action force, invoked at force-time.</param>
         /// <param name="ephemeralContext">If true, the query and state won't be remembered after the action force is finished.</param>
-        public void SetForce(float afterSeconds, Func<string> queryGetter, Func<string?> stateGetter, bool ephemeralContext = false)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetForce(float afterSeconds, Func<string> queryGetter, Func<string?> stateGetter, bool ephemeralContext = false)
         {
             float time = afterSeconds;
 
-            SetForce(shouldForce, queryGetter, stateGetter, ephemeralContext);
-            return;
+            return SetForce(shouldForce, queryGetter, stateGetter, ephemeralContext);
 
             bool shouldForce()
             {
@@ -187,7 +205,8 @@ namespace NeuroSdk.Actions
         /// Specify a time in seconds after which the actions should be forced.
         /// </summary>
         /// <param name="ephemeralContext">If true, the query and state won't be remembered after the action force is finished.</param>
-        public void SetForce(float afterSeconds, string query, string? state, bool ephemeralContext = false)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetForce(float afterSeconds, string query, string? state, bool ephemeralContext = false)
             => SetForce(afterSeconds, () => query, () => state, ephemeralContext);
 
         public void Force()
@@ -209,22 +228,25 @@ namespace NeuroSdk.Actions
         /// Specify a condition under which the actions should be unregistered and this window closed.
         /// </summary>
         /// <param name="shouldEnd">When this returns true, the actions will be unregistered.</param>
-        public void SetEnd(Func<bool> shouldEnd)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetEnd(Func<bool> shouldEnd)
         {
-            if (!ValidateFrozen()) return;
+            if (!ValidateFrozen()) return this;
 
             _shouldEndFunc = shouldEnd;
+
+            return this;
         }
 
         /// <summary>
         /// Specify a time in seconds after which the actions should be unregistered and this window closed.
         /// </summary>
-        public void SetEnd(float afterSeconds)
+        /// <returns>The <see cref="ActionWindow"/> itself for chaining.</returns>
+        public ActionWindow SetEnd(float afterSeconds)
         {
             float time = afterSeconds;
 
-            SetEnd(shouldEnd);
-            return;
+            return SetEnd(shouldEnd);
 
             bool shouldEnd()
             {

--- a/Unity/Assets/Actions/BaseNeuroAction.cs
+++ b/Unity/Assets/Actions/BaseNeuroAction.cs
@@ -16,7 +16,9 @@ namespace NeuroSdk.Actions
         /// </summary>
         protected ActionWindow? ActionWindow;
 
-        protected BaseNeuroAction() : this(null) { }
+        protected BaseNeuroAction() : this(null)
+        {
+        }
 
         protected BaseNeuroAction(ActionWindow? actionWindow)
         {

--- a/Unity/Assets/Actions/BaseNeuroAction.cs
+++ b/Unity/Assets/Actions/BaseNeuroAction.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using JetBrains.Annotations;
 using NeuroSdk.Json;
 using NeuroSdk.Websocket;
+using UnityEngine;
 
 namespace NeuroSdk.Actions
 {
@@ -13,7 +14,9 @@ namespace NeuroSdk.Actions
         /// <summary>
         /// The value that was passed to the actionWindow parameter in the constructor
         /// </summary>
-        protected readonly ActionWindow? ActionWindow;
+        protected ActionWindow? ActionWindow;
+
+        protected BaseNeuroAction() : this(null) { }
 
         protected BaseNeuroAction(ActionWindow? actionWindow)
         {
@@ -24,7 +27,7 @@ namespace NeuroSdk.Actions
         protected abstract string Description { get; }
         protected abstract JsonSchema? Schema { get; }
 
-        public virtual bool CanBeUsed() => true;
+        public virtual bool CanAddToActionWindow(ActionWindow actionWindow) => ActionWindow == null || ReferenceEquals(ActionWindow, actionWindow);
 
         ExecutionResult INeuroAction.Validate(ActionJData actionData, out object? parsedData)
         {
@@ -47,5 +50,15 @@ namespace NeuroSdk.Actions
 
         protected abstract ExecutionResult Validate(ActionJData actionData, out object? parsedData);
         protected abstract UniTask ExecuteAsync(object? data);
+
+        public void SetActionWindow(ActionWindow actionWindow)
+        {
+            if (!CanAddToActionWindow(actionWindow))
+            {
+                Debug.LogError("Cannot set the action window for this action.");
+                return;
+            }
+            ActionWindow = actionWindow;
+        }
     }
 }

--- a/Unity/Assets/Actions/INeuroAction.cs
+++ b/Unity/Assets/Actions/INeuroAction.cs
@@ -14,11 +14,13 @@ namespace NeuroSdk.Actions
         /// <summary>
         /// This is ONLY checked when the action is added to an ActionWindow, if it returns false the action won't be added.
         /// </summary>
-        bool CanBeUsed();
+        bool CanAddToActionWindow(ActionWindow actionWindow);
 
         ExecutionResult Validate(ActionJData actionData, out object? data);
         UniTask ExecuteAsync(object? data);
 
         WsAction GetWsAction();
+
+        public void SetActionWindow(ActionWindow actionWindow);
     }
 }

--- a/Unity/Assets/Actions/NeuroAction.cs
+++ b/Unity/Assets/Actions/NeuroAction.cs
@@ -12,6 +12,7 @@ namespace NeuroSdk.Actions
     [PublicAPI]
     public abstract class NeuroAction : BaseNeuroAction
     {
+        protected NeuroAction() : base() { }
         protected NeuroAction(ActionWindow? actionWindow) : base(actionWindow)
         {
         }
@@ -36,6 +37,7 @@ namespace NeuroSdk.Actions
     [PublicAPI]
     public abstract class NeuroAction<TData> : BaseNeuroAction
     {
+        protected NeuroAction() : base() { }
         protected NeuroAction(ActionWindow? actionWindow) : base(actionWindow)
         {
         }

--- a/Unity/Assets/Actions/NeuroAction.cs
+++ b/Unity/Assets/Actions/NeuroAction.cs
@@ -12,7 +12,10 @@ namespace NeuroSdk.Actions
     [PublicAPI]
     public abstract class NeuroAction : BaseNeuroAction
     {
-        protected NeuroAction() : base() { }
+        protected NeuroAction()
+        {
+        }
+
         protected NeuroAction(ActionWindow? actionWindow) : base(actionWindow)
         {
         }
@@ -37,7 +40,10 @@ namespace NeuroSdk.Actions
     [PublicAPI]
     public abstract class NeuroAction<TData> : BaseNeuroAction
     {
-        protected NeuroAction() : base() { }
+        protected NeuroAction()
+        {
+        }
+
         protected NeuroAction(ActionWindow? actionWindow) : base(actionWindow)
         {
         }

--- a/Unity/Assets/Examples/TicTacToe.cs
+++ b/Unity/Assets/Examples/TicTacToe.cs
@@ -38,10 +38,10 @@ namespace NeuroSdk.Examples
 
             if (!CheckWin())
             {
-                ActionWindow actionWindow = ActionWindow.Create(gameObject);
-                actionWindow.SetForce(0, "It is your turn. Please place an O.", "", false);
-                actionWindow.AddAction(new PlayOAction(actionWindow, this));
-                actionWindow.Register();
+                ActionWindow.Create(gameObject)
+                    .SetForce(0, "It is your turn. Please place an O.", "", false)
+                    .AddAction(new PlayOAction(this))
+                    .Register();
             }
             else
             {
@@ -122,7 +122,7 @@ namespace NeuroSdk.Examples
     {
         private readonly TicTacToe _ticTacToe;
 
-        public PlayOAction(ActionWindow window, TicTacToe ticTacToe) : base(window)
+        public PlayOAction(TicTacToe ticTacToe) : base()
         {
             _ticTacToe = ticTacToe;
         }

--- a/Unity/Assets/Examples/TicTacToe.cs
+++ b/Unity/Assets/Examples/TicTacToe.cs
@@ -122,7 +122,7 @@ namespace NeuroSdk.Examples
     {
         private readonly TicTacToe _ticTacToe;
 
-        public PlayOAction(TicTacToe ticTacToe) : base()
+        public PlayOAction(TicTacToe ticTacToe)
         {
             _ticTacToe = ticTacToe;
         }

--- a/Unity/USAGE.md
+++ b/Unity/USAGE.md
@@ -26,7 +26,7 @@ public class JudgeAction : NeuroAction<Button>
 {
     private readonly JudgeGame _judgeGame;
 
-    public JudgeAction(JudgeGame judgeGame) : base()
+    public JudgeAction(JudgeGame judgeGame)
     {
         _judgeGame = judgeGame;
     }
@@ -105,8 +105,7 @@ public void OnSceneChanged(string sceneName)
 // where LookAtAction is defined as
 public class LookAtAction: NeuroAction
 {
-    // This action is never part of an action window, so we use the parameterless base constructor
-    public LookAtAction() : base()
+    public LookAtAction()
     {
     }
 


### PR DESCRIPTION
This would allow the user to use the `ActionWindow` methods with method chaining, plus some other improvements (see below). I have also added comments to some lines in the commits to explain the purpose of the changes.

## Method chaining

Current:

```C#
ActionWindow actionWindow = ActionWindow.Create(gameObject);
actionWindow.SetForce(0, "It is your turn. Please place an O.", "", false);
actionWindow.AddAction(new PlayOAction(actionWindow, this));
actionWindow.Register();
```

Proposed:

```C#
ActionWindow.Create(gameObject)
    .SetForce(0, "It is your turn. Please place an O.", "", false)
    .AddAction(new PlayOAction(this)) // See below why there is no action window in the constructor
    .Register();
```

### Advantages

- The action window doesn't need to be saved in a variable
- It looks better (in my opinion)
- `Register()` can only be called at the end of the call chain, as it does not return the `ActionWindow`. This makes it harder to accidentally mutate a registered action.

## No more ActionWindow parameter in constructor

I added a parameterless constructor in the Action classes, which passes `null` to the base constructor. This also means that custom actions don't need to reference the base constructor anymore, since it is called by default. Actions are now added to action windows using the `void INeuroAction.SetActionWindow(ActionWindow actionWindow)` method, which is called in `AddAction` . I also added an `ActionWindow` parameter to `bool INeuroAction.CanUse()` and changed the name and implementation (signature is now `bool INeuroAction.CanAddToActionWindow(ActionWindow actionWindow)`).

**This should not break any existing code**, as the constructor with the `ActionWindow` parameter still exists. The only thing it would break is if you added a single action to multiple action windows, which I don't think works currently anyway.