### PR TITLE
Fixed the Fix for #39, Improved the implementation of the IncomingData class_name

### DIFF
--- a/Godot/addons/neuro-sdk/messages/api/incoming_data.gd
+++ b/Godot/addons/neuro-sdk/messages/api/incoming_data.gd
@@ -1,18 +1,64 @@
 class_name IncomingData
 
+
 var _data: Dictionary
 
-func _init(data: Dictionary):
+
+func _init(data: Dictionary) -> void:
 	_data = data
+
+
+func get_full_data() -> Dictionary:
+	return _data.duplicate(true)
+
 
 func get_string(name: String, default: String = "") -> String:
 	var value = _data.get(name, default)
-	if typeof(value) != TYPE_STRING:
+	if value is not String:
 		value = default
+
 	return value
 
+
+func get_number(name: String, default: float = 0.0) -> float:
+	return get_float(name, default)
+
+
 func get_object(name: String, default: Dictionary = {}) -> IncomingData:
-	var value = _data.get(name, {})
-	if typeof(value) != TYPE_DICTIONARY:
+	var value = _data.get(name, default)
+	if value is not Dictionary:
 		value = default
+
 	return IncomingData.new(value)
+
+
+func get_array(name: String, default: Array) -> Array:
+	var value = _data.get(name, default)
+	if value is not Array:
+		value = default
+
+	return value
+
+
+func get_boolean(name: String, default: bool = false) -> bool:
+	var value = _data.get(name, default)
+	if value is not bool:
+		value = default
+
+	return value
+
+
+func get_int(name: String, default: int = 0) -> int:
+	var value = _data.get(name, default)
+	if value is not int and value is not float:
+		value = default
+
+	return int(value)
+
+
+func get_float(name: String, default: float = 0.0) -> float:
+	var value = _data.get(name, default)
+	if value is not int and value is not float:
+		value = default
+
+	return float(value)

--- a/Godot/addons/neuro-sdk/messages/api/outgoing_message.gd
+++ b/Godot/addons/neuro-sdk/messages/api/outgoing_message.gd
@@ -1,15 +1,18 @@
 class_name OutgoingMessage
 
+
 func _get_command() -> String:
 	push_error("OutgoingMessage._get_command() is not implemented.")
 	return "invalid"
 
-# Returns Dictionary | null
-func _get_data():
-	return null
+
+func _get_data() -> Dictionary:
+	return {}
+
 
 func merge(_other: OutgoingMessage) -> bool:
 	return false
+
 
 func get_ws_message() -> WsMessage:
 	return WsMessage.new(_get_command(), _get_data(), NeuroSdkConfig.game)

--- a/Godot/addons/neuro-sdk/messages/api/ws_message.gd
+++ b/Godot/addons/neuro-sdk/messages/api/ws_message.gd
@@ -1,19 +1,22 @@
 class_name WsMessage
 
+
 var command: String
-var data
+var data: Dictionary
 var game: String
 
-func _init(command_: String, data_, game_: String):
-	command = command_
-	data = data_
-	game = game_
+
+func _init(_command: String, _data: Dictionary, _game: String):
+	command = _command
+	data = _data
+	game = _game
+
 
 func get_data() -> Dictionary:
-	if data == null:
+	if data.is_empty():
 		return {
 			"command": command,
-			"game": game,
+			"game": game
 		}
 
 	return {

--- a/Godot/addons/neuro-sdk/websocket/websocket.gd
+++ b/Godot/addons/neuro-sdk/websocket/websocket.gd
@@ -38,7 +38,7 @@ func _process(delta) -> void:
 			_ws_reconnect()
 
 func _ws_start() -> void:
-	push_warning("Initializing Websocket connection")
+	print("Initializing Websocket connection")
 
 	if _socket != null:
 		var state: int = _socket.get_ready_state();


### PR DESCRIPTION
* Fixed a breaking issue from the Fix for #39.
* Added getters in the [IncomingData](https://github.com/averagebrine/neuro-game-sdk/blob/20f6625a373845b4a0da58305408b3115689bd5e/Godot/addons/neuro-sdk/messages/api/incoming_data.gd) class_name for *all* valid JSON schema types, except for `null`.
* Added an additional getter that returns a full copy of the `_data` dictionary, for advanced users. Previously you could already simply grab it directly, but since it's prefixed as private, you shouldn't have to, and probably shouldn't.
* Stopped warning unnecessarily during startup in [websocket.gd](https://github.com/averagebrine/neuro-game-sdk/blob/20f6625a373845b4a0da58305408b3115689bd5e/Godot/addons/neuro-sdk/websocket/websocket.gd#L41), because it was driving me crazy.

Additionally, all the files I worked on now _rougly_ follow Godot's GDScript style guide, but of course, the rest of the project **does not.** So, I can leave that out for now if you prefer.