### PR TITLE
Add useful signals to Websocket when it disconnects, fails to connect, or connects successfully

### DIFF
--- a/Godot/addons/neuro-sdk/neuro_sdk.tscn
+++ b/Godot/addons/neuro-sdk/neuro_sdk.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" path="res://addons/neuro-sdk/websocket/websocket.gd" id="1_dnmry"]
 [ext_resource type="Script" path="res://addons/neuro-sdk/actions/neuro_action_handler.gd" id="2_25l11"]
 
-[node name="Neuro SDK" type="Node"]
+[node name="Websocket" type="Node"]
 script = ExtResource("1_dnmry")
 
-[node name="Action Handler" type="Node" parent="."]
+[node name="ActionHandler" type="Node" parent="."]
 script = ExtResource("2_25l11")

--- a/Godot/addons/neuro-sdk/plugin.gd
+++ b/Godot/addons/neuro-sdk/plugin.gd
@@ -2,13 +2,19 @@
 extends EditorPlugin
 
 
-# this could probably be more descriptive, along with the singleton itself.
-const AUTOLOAD_NAME: String = "neuro_sdk"
+const AUTOLOAD_NAME: String = "Websocket"
 
 
 func _enter_tree() -> void:
+	# For safety, remove the previously malnamed singleton, if it still exists.
+	if ProjectSettings.has_setting('autoload/neuro_sdk'):
+		remove_autoload_singleton("neuro_sdk")
+
 	add_autoload_singleton(AUTOLOAD_NAME, "res://addons/neuro-sdk/neuro_sdk.tscn")
 
 
 func _exit_tree() -> void:
+	if ProjectSettings.has_setting('autoload/neuro_sdk'):
+		remove_autoload_singleton("neuro_sdk")
+
 	remove_autoload_singleton(AUTOLOAD_NAME)

--- a/Godot/addons/neuro-sdk/websocket/command_handler.gd
+++ b/Godot/addons/neuro-sdk/websocket/command_handler.gd
@@ -20,7 +20,7 @@ func register_all() -> void:
 			var script = load(script_path)
 			if script:
 				var node = script.new()
-				node.name = file_name
+				node.name = file_name.get_file().get_basename().to_pascal_case()
 				add_child(node)
 				handlers.append(node)
 				print("Added websocket message node: %s" % [script_path])

--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -17,7 +17,7 @@ boot_splash/bg_color=Color(0, 0, 0, 1)
 
 [autoload]
 
-neuro_sdk="*res://addons/neuro-sdk/neuro_sdk.tscn"
+Websocket="*res://addons/neuro-sdk/neuro_sdk.tscn"
 
 [debug]
 


### PR DESCRIPTION
The Websocket autoload now has a few QoL signals.
---

You can use these to know whether Neuro/Randy connect successfully, and toggle related gameplay features.

**Example:**
```gdscript
func _ready() -> void:
	Websocket.connected.connect(neuro_connected)


func neuro_connected() -> void:
	# Enable related features
	pass
```

### Important change:
Before, the `Websocket` class_name was being given the autoload name `neuro_sdk`.

Previously, you could access the singleton via `neuro_sdk.some_func()` _in addition_ to being able to access static methods and variables with the class_name `Websocket`. It's bad practice to use class_names in autoloads, since autoloads generate their own class_names.

While the static variables have now been removed(made non-static), the autoload has been renamed to `Websocket`, so no existing code referencing it needed to be changed. Everything works as before.

> [!NOTE]
>  Since the autoload was renamed, your console might get an error when it first reloads the changes, as it figures out where `Websocket` went. Don't worry, nothing went wrong. Your project should continue to work as before, and the error won't persist if you reload again regardless.