### PR TITLE
Add a small section for the signals to the documentation

### DIFF
--- a/Godot/USAGE.md
+++ b/Godot/USAGE.md
@@ -198,3 +198,41 @@ else Failure
     end
 end
 ```
+
+## Signals
+
+There a few signals built-in to the `Websocket` autoload you can use to know when Neuro connects or disconnects:
+
+* `Websocket.connected`
+
+* `Websocket.failed_to_connect(error: Error)`
+
+* `Websocket.disconnected(code: Code)`
+
+
+Keep in mind the `connected` signal is emitted as soon as the `Websocket` autoload can connect, which may be before non-autoload nodes are ready. If you need to check the connection after this point, you can simply check the `websocket_is_connected` bool.
+
+Since the Websocket has an autoload class name, you can connect to it from any script:
+
+```py
+# Some Node
+# ...
+func _ready() -> void:
+    if Websocket.websocket_is_connected:
+        neuro_connected()
+
+    Websocket.disconnected.connect(neuro_disconnected)
+    
+func neuro_connected() -> void:
+    print("Neuro is connected! Yipee!")
+
+	# Enable related features
+
+func neuro_disconnected(code: int) -> void:
+    push_warning("Neuro disconnected with code %d!" % code)
+
+    # Disable related features
+
+func neuro_failed_to_connect(err: Error) -> void:
+    push_warning("Neuro failed to connect with error: %s!" % str(err))
+```

--- a/Godot/addons/neuro-sdk/websocket/websocket.gd
+++ b/Godot/addons/neuro-sdk/websocket/websocket.gd
@@ -2,7 +2,7 @@ extends Node
 
 
 signal connected
-signal connection_failed(reason: String)
+signal connection_failed(error: Error)
 signal disconnected(code: int)
 
 const POLL_INTERVAL := 1.0 / 30.0
@@ -72,7 +72,7 @@ func _ws_start() -> void:
 
 	_socket = WebSocketPeer.new() # idk if i can reuse the same one
 
-	var err: int = _socket.connect_to_url(ws_url)
+	var err: Error = _socket.connect_to_url(ws_url)
 	if err != OK:
 		push_warning("Could not connect to websocket, error code %d" % [err])
 		_ws_reconnect()

--- a/Godot/addons/neuro-sdk/websocket/websocket.gd
+++ b/Godot/addons/neuro-sdk/websocket/websocket.gd
@@ -13,7 +13,7 @@ var _message_queue := MessageQueue.new()
 var _command_handler: CommandHandler
 
 var _elapsed_time := 0.0
-var _was_connected: bool = false
+var websocket_is_connected: bool = false
 
 
 func _enter_tree() -> void:
@@ -44,17 +44,18 @@ func _process(delta) -> void:
 			_ws_read()
 			_ws_write()
 
-			if not _was_connected:
-				_was_connected = true
+			if not websocket_is_connected:
+				websocket_is_connected = true
 				connected.emit()
 
 		WebSocketPeer.STATE_CLOSED:
 			var code: int = _socket.get_close_code()
-			push_warning("Websocket closed with code: %d" % [code])
+			push_warning("Websocket closed with code: %d" % code)
 			_ws_reconnect()
 
-			_was_connected = false
-			disconnected.emit(code)
+			if websocket_is_connected:
+				websocket_is_connected = false
+				disconnected.emit(code)
 
 
 func _ws_start() -> void:


### PR DESCRIPTION
Added a simple check to make sure we don't spam the disconnected signal, and used the Error type instead of int where needed.

Also renamed the previously pseudo-private variable `_was_connected` to `websocket_is_connected` so you can check the connected status _after_ the connection has already been established (since the autoload will probably emit the connected signal for before most nodes are actually ready, since it's an autoload)