### PR TITLE
Add Gary (backend implementation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Third-party SDKs created and maintained by the community.
 ### Tools
 - [Tony](https://github.com/Pasu4/neuro-api-tony) is a graphical testing interface, similar to Randy, but it allows the user to write messages manually.
 - [Jippity](https://github.com/EnterpriseScratchDev/neuro-api-jippity) is a testing tool that aims to be a more "realistic" version of Randy, by using OpenAI to mimic Neuro.
+- [Gary](https://github.com/Govorunb/gary) is another backend implementation for advanced use. Originally created for testing with local LLMs like Llama, now also has support for a Randy-like "random generator" mode and a web UI for Tony-like manual sending.
 
 ## Information 
 


### PR DESCRIPTION
[As promised](https://github.com/VedalAI/neuro-game-sdk/issues/44#issue-2781897039), here's Gaming Gary™️, my backend implementation to test game integrations with local models. It's not giga enterprise polished, but I feel like I've picked off enough of the low hanging fruit to get it listed here without embarrassing the last 5 generations of my ancestry.

It does some (I think) neat technical things like:
- Coercing the model to nearly always adhere to the JSON schema (I did not code this, it's a [library](https://github.com/guidance-ai/guidance))
- Casting some context window magic to make it able to play uninterrupted potentially until the heat death of the universe (I did not test for that long sorry)
  - Just imagine an LLM eternally locked in to play Balatro... isn't it poetic
- Also you can let the model "yap" (configurable) so you should also imagine that LLM shouting for help into the endless void (very [normal](https://x.com/skcd42/status/1894375185836306470) way to treat these things)

On the intelligence scale, this occupies some middle ground between Randy and Jippity. Exactly where on the scale depends on your GPU/model size, but from my testing even 8GB VRAM can go a pretty long way.

And, if you're not satisfied with your model, you can use the Randy engine or DIY with Tony-like manual sending through the web UI. Surely a synergistic win-win for all stakeholders